### PR TITLE
Update Docker build context and file paths

### DIFF
--- a/.github/workflows/publish-docker-package.yml
+++ b/.github/workflows/publish-docker-package.yml
@@ -48,7 +48,7 @@ jobs:
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
-          context: ./server
+          context: .
           file: server/src/Api/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/server/src/Api/Dockerfile
+++ b/server/src/Api/Dockerfile
@@ -7,14 +7,14 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["Directory.Packages.props", "."]
-COPY ["Directory.Build.props", "."]
-COPY ["src/Api/Api.csproj", "src/Api/"]
-COPY ["src/Infrastructure/Infrastructure.csproj", "src/Infrastructure/"]
-COPY ["src/Application/Application.csproj", "src/Application/"]
-COPY ["src/Domain/Domain.csproj", "src/Domain/"]
+COPY ["server/Directory.Packages.props", "."]
+COPY ["server/Directory.Build.props", "."]
+COPY ["server/src/Api/Api.csproj", "src/Api/"]
+COPY ["server/src/Infrastructure/Infrastructure.csproj", "src/Infrastructure/"]
+COPY ["server/src/Application/Application.csproj", "src/Application/"]
+COPY ["server/src/Domain/Domain.csproj", "src/Domain/"]
 RUN dotnet restore "./src/Api/Api.csproj"
-COPY . .
+COPY server/ .
 WORKDIR "/src/src/Api"
 RUN dotnet build "./Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
 


### PR DESCRIPTION
Changed the Docker build context in the GitHub workflow to the repository root and updated file paths in the Dockerfile to reference files under the 'server' directory. This ensures correct file resolution during Docker image build and aligns with the project structure.