### PR TITLE
Change energy entry update to PUT and add validator

### DIFF
--- a/server/src/Api/Endpoints/Vehicles/EnergyEntries/UpdateEnergyEntry.cs
+++ b/server/src/Api/Endpoints/Vehicles/EnergyEntries/UpdateEnergyEntry.cs
@@ -13,7 +13,7 @@ public class UpdateEnergyEntry : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapPost(
+        app.MapPut(
                 "vehicles/{vehicleId:guid}/energy-entries/{id:guid}",
                 async (UpdateEnergyEntryRequest request, Guid vehicleId, Guid id, ISender sender, CancellationToken cancellationToken) =>
                 {

--- a/server/src/Application/DependencyInjection.cs
+++ b/server/src/Application/DependencyInjection.cs
@@ -18,6 +18,7 @@ public static class DependencyInjection
         // Register services
         services.AddScoped<IVehicleEnergyCompatibilityService, VehicleEnergyCompatibilityService>();
         services.AddScoped<IEnergyEntryFilterService, EnergyEntryFilterService>();
+        services.AddScoped<IEnergyEntryMileageValidator, EnergyEntryMileageValidator>();
 
         services.AddMediatR(config =>
         {


### PR DESCRIPTION
Switched the update endpoint for energy entries from POST to PUT for proper REST semantics. Added IEnergyEntryMileageValidator registration to dependency injection for improved validation.